### PR TITLE
Feat/sns sqs

### DIFF
--- a/src/main/java/com/example/mockbank/adapter/in/web/sqs/AwsSqsListener.java
+++ b/src/main/java/com/example/mockbank/adapter/in/web/sqs/AwsSqsListener.java
@@ -2,6 +2,7 @@ package com.example.mockbank.adapter.in.sqs;
 
 import com.example.mockbank.application.dto.AccountCreatedEvent;
 import com.example.mockbank.application.service.AccountService;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -41,10 +42,17 @@ public class AwsSqsListener {
                 for (Message message : messages) {
                     try {
                         log.info("📨 SQS 수신: {}", message.body());
-                        AccountCreatedEvent event = objectMapper.readValue(message.body(), AccountCreatedEvent.class);
+
+                        // 1. SQS → SNS 구조의 래핑 메시지 처리
+                        JsonNode root = objectMapper.readTree(message.body());
+                        String innerJson = root.get("Message").asText(); // 내부 JSON 문자열 꺼냄
+
+                        // 2. 실제 비즈니스 DTO로 파싱
+                        AccountCreatedEvent event = objectMapper.readValue(innerJson, AccountCreatedEvent.class);
                         accountService.createAccountFromEvent(event);
+
                     } catch (Exception e) {
-                        log.error("SQS 메시지 처리 실패", e);
+                        log.warn("SQS 메시지 처리 실패 - 무시된 메시지: {}", message.body(), e);
                     }
                 }
             }

--- a/src/main/java/com/example/mockbank/adapter/out/messaging/AwsSnsSender.java
+++ b/src/main/java/com/example/mockbank/adapter/out/messaging/AwsSnsSender.java
@@ -1,0 +1,59 @@
+package com.example.mockbank.adapter.out.messaging;
+
+import com.example.mockbank.application.dto.AccountCreatedEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwsSnsSender {
+
+    private final SnsClient snsClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${cloud.aws.sns.notification-topic-arn}")
+    private String topicArn;
+
+    public void sendNotification(Long userId, String email, String nickname, String userName) {
+        try {
+            // 1. 이벤트 객체 생성
+            AccountCreatedEvent event = new AccountCreatedEvent(
+                    userId, email, nickname, userName, LocalDateTime.now()
+            );
+
+            // 2. JSON 직렬화
+            String jsonMessage = objectMapper.writeValueAsString(event);
+
+            // 3. MessageAttribute에 queueId 포함
+            String queueId = String.format("%d|USER_NOTIFICATION|%s|Welcome!",
+                    userId, LocalDateTime.now());
+
+            PublishRequest request = PublishRequest.builder()
+                    .topicArn(topicArn)
+                    .message(jsonMessage)
+                    .messageAttributes(Map.of(
+                            "queueId", MessageAttributeValue.builder()
+                                    .dataType("String")
+                                    .stringValue(queueId)
+                                    .build()
+                    ))
+                    .build();
+
+            log.info("SNS 전송: queueId={}, json={}", queueId, jsonMessage);
+            snsClient.publish(request);
+
+        } catch (Exception e) {
+            log.error("SNS 전송 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/example/mockbank/application/dto/AccountCreateRequest.java
+++ b/src/main/java/com/example/mockbank/application/dto/AccountCreateRequest.java
@@ -6,6 +6,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class AccountCreateRequest {
-    private String accountNumber;
     private Long userId;
+    private String userName;
 }

--- a/src/main/java/com/example/mockbank/application/dto/AccountCreatedEvent.java
+++ b/src/main/java/com/example/mockbank/application/dto/AccountCreatedEvent.java
@@ -1,12 +1,18 @@
 package com.example.mockbank.application.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class AccountCreatedEvent {
     private Long userId;
     private String email;
     private String nickname;
-    private String createdAt;
+    private String userName;
+    private LocalDateTime createdAt;
 }
-

--- a/src/main/java/com/example/mockbank/application/service/AccountService.java
+++ b/src/main/java/com/example/mockbank/application/service/AccountService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -18,50 +19,52 @@ public class AccountService {
 
     private final AccountRepository accountRepository;
 
-    public AccountResponse createAccount(AccountCreateRequest request) {
-        Account account = Account.builder()
-                .accountNumber(request.getAccountNumber())
-                .userId(request.getUserId())
+    private String generateAccountNumber() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+    }
+
+    // 내부 공통 로직으로 계좌 생성
+    private Account createAccountInternal(Long userId, String userName) {
+        return Account.builder()
+                .accountNumber(generateAccountNumber())
+                .userId(userId)
+                .userName(userName)
                 .balance(BigDecimal.ZERO)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
+    }
 
+    // 일반 요청으로 계좌 생성
+    public AccountResponse createAccount(AccountCreateRequest request) {
+        Account account = createAccountInternal(request.getUserId(), request.getUserName());
         Account saved = accountRepository.save(account);
         return AccountResponse.from(saved);
+    }
+
+    // 이벤트 기반 계좌 생성
+    public void createAccountFromEvent(AccountCreatedEvent event) {
+        Account account = createAccountInternal(event.getUserId(), event.getUserName());
+        accountRepository.save(account);
+        log.info("계좌 생성 완료 for userId={}", event.getUserId());
     }
 
     public AccountResponse getAccount(String accountNumber) {
         Account account = accountRepository.findByAccountNumber(accountNumber)
                 .orElseThrow(() -> new IllegalArgumentException("Account not found"));
-
         return AccountResponse.from(account);
     }
 
     public BalanceResponse getBalance(String accountNumber) {
         Account account = accountRepository.findByAccountNumber(accountNumber)
                 .orElseThrow(() -> new IllegalArgumentException("Account not found"));
-
         return new BalanceResponse(account.getAccountNumber(), account.getBalance());
     }
 
     public List<TransactionResponse> getTransactions(String accountNumber) {
-        // 실제 DB 저장은 안 하지만, 가상의 거래내역 생성
         return List.of(
                 new TransactionResponse("DEPOSIT", new BigDecimal("100000"), LocalDateTime.now().minusDays(2)),
                 new TransactionResponse("WITHDRAWAL", new BigDecimal("30000"), LocalDateTime.now().minusDays(1))
         );
     }
-
-    public void createAccountFromEvent(AccountCreatedEvent event) {
-        Account account = Account.builder()
-                .userId(event.getUserId())
-                .createdAt(LocalDateTime.now())
-                .balance(BigDecimal.ZERO)
-                .build();
-
-        accountRepository.save(account);
-        log.info("계좌 생성 완료 for userId={}", event.getUserId());
-    }
-
 }

--- a/src/main/java/com/example/mockbank/config/AwsConfig.java
+++ b/src/main/java/com/example/mockbank/config/AwsConfig.java
@@ -1,0 +1,47 @@
+package com.example.mockbank.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${aws.key.access.id}")
+    private String accessKey;
+
+    @Value("${aws.key.access.secret}")
+    private String secretKey;
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public SnsClient snsClient() {
+        return SnsClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+
+    @Bean
+    public SqsClient sqsClient() {
+        return SqsClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}


### PR DESCRIPTION
- AWS SQS Listener에서 SNS 래핑 메시지 파싱 처리 (Message 필드 추출 후 AccountCreatedEvent 역직렬화)
- AccountCreatedEvent DTO 추가 (userId, email, nickname, userName, createdAt)
- AccountService.createAccountFromEvent 메서드 구현 및 통합
- 계좌 생성 시 userId, userName, 계좌번호 등 정상 반영되도록 수정
- 예외 발생 시 메시지 무시 및 로그 출력 처리