### PR TITLE
Feat/mock 계좌 생성/거래내역 생성 로직 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 
     dependencies {
         runtimeOnly 'com.mysql:mysql-connector-j'
+
+        // Redis
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     }
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/java/com/example/mockbank/adapter/in/messaging/AccountSqsListener.java
+++ b/src/main/java/com/example/mockbank/adapter/in/messaging/AccountSqsListener.java
@@ -24,7 +24,7 @@ public class AccountSqsListener {
     private final ObjectMapper objectMapper;
     private final AccountService accountService;
 
-    @Value("${aws.url.sqs.notification}")
+    @Value("${aws.url.sqs.account}")
     private String queueUrl; // application.properties에 있는 SQS 큐 URL
 
     @PostConstruct

--- a/src/main/java/com/example/mockbank/adapter/in/messaging/AccountSqsListener.java
+++ b/src/main/java/com/example/mockbank/adapter/in/messaging/AccountSqsListener.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.concurrent.Executors;
 
@@ -85,6 +86,11 @@ public class AccountSqsListener {
             req.setUserId(event.get("userId").asLong());
             req.setUserName(event.has("userName") ? event.get("userName").asText() : null);
             req.setAccountNumber(generateAccountNumber());
+            if (event.has("salary") && !event.get("salary").isNull()) {
+                req.setSalary(new BigDecimal(event.get("salary").asText()));
+            } else {
+                req.setSalary(null);
+            }
 
             accountService.createAccount(req);
 

--- a/src/main/java/com/example/mockbank/adapter/in/web/AccountController.java
+++ b/src/main/java/com/example/mockbank/adapter/in/web/AccountController.java
@@ -46,22 +46,14 @@ public class AccountController {
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<ApiResponse<AccountResponse>> getAccount(
-            @PathVariable Long userId,
-            @RequestHeader(value = "Authorization", required = false) String authorization
-    ) {
-        validateAuthorizationHeader(authorization);
+    public ResponseEntity<ApiResponse<AccountResponse>> getAccount(@PathVariable Long userId) {
         return ResponseEntity
                 .status(SuccessCode.GET_ACCOUNT_SUCCESS.getStatus())
                 .body(ApiResponse.onSuccess(SuccessCode.GET_ACCOUNT_SUCCESS, accountService.getAccount(userId)));
     }
 
     @GetMapping("/{userId}/transactions")
-    public ResponseEntity<ApiResponse<List<TransactionResponse>>> getTransactions(
-            @PathVariable Long userId,
-            @RequestHeader(value = "Authorization", required = false) String authorization
-    ) {
-        validateAuthorizationHeader(authorization);
+    public ResponseEntity<ApiResponse<List<TransactionResponse>>> getTransactions(@PathVariable Long userId) {
         return ResponseEntity
                 .status(SuccessCode.GET_TRANSACTIONS_SUCCESS.getStatus())
                 .body(ApiResponse.onSuccess(SuccessCode.GET_TRANSACTIONS_SUCCESS, accountService.getTransactions(userId)));
@@ -79,11 +71,4 @@ public class AccountController {
         );
         return ApiResponse.onSuccess(SuccessCode.GET_TRANSACTIONS_STATS_SUCCESS, resp);
     }
-
-    private void validateAuthorizationHeader(String authorization) {
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-    }
-
 }

--- a/src/main/java/com/example/mockbank/adapter/in/web/AccountController.java
+++ b/src/main/java/com/example/mockbank/adapter/in/web/AccountController.java
@@ -67,6 +67,19 @@ public class AccountController {
                 .body(ApiResponse.onSuccess(SuccessCode.GET_TRANSACTIONS_SUCCESS, accountService.getTransactions(userId)));
     }
 
+    @PostMapping("/{userId}/transactions/stats")
+    public ApiResponse<TransactionStatResponse> getTransactionStats(
+            @PathVariable Long userId,
+            @RequestBody TransactionStatRequest request
+    ) {
+        TransactionStatResponse resp = accountService.getTransactionStats(
+                userId,
+                request.getStartYM(),
+                request.getEndYM()
+        );
+        return ApiResponse.onSuccess(SuccessCode.GET_TRANSACTIONS_STATS_SUCCESS, resp);
+    }
+
     private void validateAuthorizationHeader(String authorization) {
         if (authorization == null || !authorization.startsWith("Bearer ")) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);

--- a/src/main/java/com/example/mockbank/adapter/in/web/AccountController.java
+++ b/src/main/java/com/example/mockbank/adapter/in/web/AccountController.java
@@ -64,9 +64,6 @@ public class AccountController {
             @PathVariable Long userId,
             @RequestBody TransactionStatRequest request
     ) {
-        if (request.getStartYM().isAfter(request.getEndYM())) {
-            throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
-        }
         TransactionStatResponse resp = accountService.getTransactionStats(
                 userId,
                 request.getStartYM(),

--- a/src/main/java/com/example/mockbank/adapter/in/web/AccountController.java
+++ b/src/main/java/com/example/mockbank/adapter/in/web/AccountController.java
@@ -64,6 +64,9 @@ public class AccountController {
             @PathVariable Long userId,
             @RequestBody TransactionStatRequest request
     ) {
+        if (request.getStartYM().isAfter(request.getEndYM())) {
+            throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
+        }
         TransactionStatResponse resp = accountService.getTransactionStats(
                 userId,
                 request.getStartYM(),

--- a/src/main/java/com/example/mockbank/application/dto/AccountCreateRequest.java
+++ b/src/main/java/com/example/mockbank/application/dto/AccountCreateRequest.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.math.BigDecimal;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,4 +20,6 @@ public class AccountCreateRequest {
 
     @NotBlank(message = "유저명은 필수입니다.")
     private String userName;
+
+    private BigDecimal salary;
 }

--- a/src/main/java/com/example/mockbank/application/dto/TransactionStatRequest.java
+++ b/src/main/java/com/example/mockbank/application/dto/TransactionStatRequest.java
@@ -1,0 +1,15 @@
+package com.example.mockbank.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.YearMonth;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionStatRequest {
+    private YearMonth startYM; // ex: 2025-06
+    private YearMonth endYM;   // ex: 2025-07
+}

--- a/src/main/java/com/example/mockbank/application/dto/TransactionStatRequest.java
+++ b/src/main/java/com/example/mockbank/application/dto/TransactionStatRequest.java
@@ -1,5 +1,6 @@
 package com.example.mockbank.application.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,9 @@ import java.time.YearMonth;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TransactionStatRequest {
+    @NotNull(message = "시작 월은 필수입니다.")
     private YearMonth startYM; // ex: 2025-06
+
+    @NotNull(message = "종료 월은 필수입니다.")
     private YearMonth endYM;   // ex: 2025-07
 }

--- a/src/main/java/com/example/mockbank/application/dto/TransactionStatResponse.java
+++ b/src/main/java/com/example/mockbank/application/dto/TransactionStatResponse.java
@@ -1,0 +1,19 @@
+package com.example.mockbank.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TransactionStatResponse {
+    private BigDecimal totalIncome;
+    private BigDecimal totalExpense;
+    private BigDecimal avgMonthlyIncome;
+    private BigDecimal avgMonthlyExpense;
+}

--- a/src/main/java/com/example/mockbank/application/service/AccountService.java
+++ b/src/main/java/com/example/mockbank/application/service/AccountService.java
@@ -58,7 +58,7 @@ public class AccountService {
             else balance = balance.subtract(tx.getAmount());
             if (balance.compareTo(BigDecimal.ZERO) < 0) balance = BigDecimal.ZERO;
         }
-        account.setBalance(balance);
+        account.updateBalance(balance);
         accountRepository.save(account);
 
         return AccountResponse.from(account);

--- a/src/main/java/com/example/mockbank/application/service/AccountService.java
+++ b/src/main/java/com/example/mockbank/application/service/AccountService.java
@@ -35,7 +35,6 @@ public class AccountService {
         boolean isSalaryRandom = false;
         if (salary == null) {
             isSalaryRandom = true;
-            salary = null; // 계좌에 null 저장 (거래내역은 별도로 랜덤생성)
         }
 
         Account account = Account.builder()
@@ -50,7 +49,7 @@ public class AccountService {
         account = accountRepository.save(account);
 
         List<Transaction> transactions = generateInitialTransactions(account, salary, isSalaryRandom);
-        for (Transaction tx : transactions) transactionRepository.save(tx);
+        transactionRepository.saveAll(transactions);
 
         // balance 재계산 (최신 거래까지)
         BigDecimal balance = BigDecimal.ZERO;

--- a/src/main/java/com/example/mockbank/application/service/AccountService.java
+++ b/src/main/java/com/example/mockbank/application/service/AccountService.java
@@ -144,8 +144,7 @@ public class AccountService {
 
     @Transactional
     public AccountResponse deposit(Long userId, DepositRequest request) {
-        Account account = accountRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
+        Account account = accountRepository.getOrThrowByUserId(userId);
 
         account.deposit(request.getAmount());
         accountRepository.save(account);
@@ -165,8 +164,7 @@ public class AccountService {
 
     @Transactional
     public AccountResponse withdraw(Long userId, WithdrawRequest request) {
-        Account account = accountRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
+        Account account = accountRepository.getOrThrowByUserId(userId);
 
         BigDecimal withdrawAmount = request.getAmount();
         if (account.getBalance().compareTo(withdrawAmount) < 0) {
@@ -192,15 +190,13 @@ public class AccountService {
 
     @Transactional(readOnly = true)
     public AccountResponse getAccount(Long userId) {
-        Account account = accountRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
+        Account account = accountRepository.getOrThrowByUserId(userId);
         return AccountResponse.from(account);
     }
 
     @Transactional(readOnly = true)
     public List<TransactionResponse> getTransactions(Long userId) {
-        Account account = accountRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
+        Account account = accountRepository.getOrThrowByUserId(userId);
 
         return account.getTransactions().stream()
                 .sorted(Comparator.comparing(Transaction::getCreatedAt).reversed())
@@ -219,8 +215,7 @@ public class AccountService {
             throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
         }
 
-        Account account = accountRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
+        Account account = accountRepository.getOrThrowByUserId(userId);
 
         // 1. 거래 내역 필터링
         List<Transaction> txs = account.getTransactions().stream()

--- a/src/main/java/com/example/mockbank/application/service/AccountService.java
+++ b/src/main/java/com/example/mockbank/application/service/AccountService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Random;
+import java.util.ArrayList;
 
 
 @Service
@@ -27,17 +29,99 @@ public class AccountService {
 
     @Transactional
     public AccountResponse createAccount(AccountCreateRequest request) {
+        // salary: null이면 200~500만 랜덤생성
+        BigDecimal salary = request.getSalary();
+        boolean isSalaryRandom = false;
+        if (salary == null) {
+            salary = BigDecimal.valueOf(new Random().nextInt(301) + 200)
+                    .multiply(BigDecimal.valueOf(10000)); // 200~500만
+            isSalaryRandom = true;
+        }
+
         Account account = Account.builder()
                 .accountNumber(request.getAccountNumber())
                 .userId(request.getUserId())
                 .userName(request.getUserName())
+                .salary(salary)
                 .balance(BigDecimal.ZERO)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        Account saved = accountRepository.save(account);
-        return AccountResponse.from(saved);
+        account = accountRepository.save(account);
+
+        // 거래내역 자동 생성
+        List<Transaction> transactions = generateInitialTransactions(account, salary, isSalaryRandom);
+        for (Transaction tx : transactions) {
+            transactionRepository.save(tx);
+        }
+
+        // 잔액 계산/적용
+        BigDecimal balance = BigDecimal.ZERO;
+        for (Transaction tx : transactions) {
+            if (tx.getType() == TransactionType.DEPOSIT) balance = balance.add(tx.getAmount());
+            else balance = balance.subtract(tx.getAmount());
+            if (balance.compareTo(BigDecimal.ZERO) < 0) balance = BigDecimal.ZERO;
+        }
+        account.setBalance(balance);
+        accountRepository.save(account);
+
+        return AccountResponse.from(account);
+    }
+
+    // 거래내역 생성 로직
+    private List<Transaction> generateInitialTransactions(Account account, BigDecimal salary, boolean isSalaryRandom) {
+        List<Transaction> all = new ArrayList<>();
+        Random rand = new Random();
+
+        int monthCount = rand.nextInt(27) + 10; // 10~36개월
+        LocalDateTime now = LocalDateTime.now();
+        BigDecimal currentBalance = BigDecimal.ZERO;
+
+        for (int i = 0; i < monthCount; i++) {
+            LocalDateTime month = now.minusMonths(i);
+            int txCount = rand.nextInt(11) + 10; // 10~20건
+            int salaryIdx = rand.nextInt(txCount);
+
+            for (int t = 0; t < txCount; t++) {
+                TransactionType type;
+                BigDecimal amount;
+
+                if (t == salaryIdx) {
+                    type = TransactionType.DEPOSIT;
+                    amount = salary;
+                } else {
+                    type = rand.nextBoolean() ? TransactionType.DEPOSIT : TransactionType.WITHDRAWAL;
+                    amount = BigDecimal.valueOf(rand.nextInt(700_001)); // 0~70만
+                    if (amount.compareTo(BigDecimal.ZERO) == 0) amount = BigDecimal.valueOf(1000);
+                }
+
+                String memo = (t == salaryIdx)
+                        ? (isSalaryRandom ? "수입" : "월급")
+                        : (type == TransactionType.DEPOSIT ? "입금" : "출금");
+
+                int day = (t == salaryIdx) ? 28 : rand.nextInt(27) + 1;
+                LocalDateTime txDate = month.withDayOfMonth(Math.min(day, month.toLocalDate().lengthOfMonth()))
+                        .withHour(rand.nextInt(10) + 8);
+
+                // 음수 방지
+                if (type == TransactionType.WITHDRAWAL && currentBalance.compareTo(amount) < 0) continue;
+
+                Transaction tx = Transaction.builder()
+                        .account(account)
+                        .amount(amount)
+                        .type(type)
+                        .memo(memo)
+                        .description(memo)
+                        .createdAt(txDate)
+                        .build();
+
+                all.add(tx);
+                if (type == TransactionType.DEPOSIT) currentBalance = currentBalance.add(amount);
+                else currentBalance = currentBalance.subtract(amount);
+            }
+        }
+        return all;
     }
 
     @Transactional
@@ -108,5 +192,4 @@ public class AccountService {
     public boolean existsByAccountNumber(String accountNumber) {
         return accountRepository.existsByAccountNumber(accountNumber);
     }
-    //
 }

--- a/src/main/java/com/example/mockbank/application/service/AccountService.java
+++ b/src/main/java/com/example/mockbank/application/service/AccountService.java
@@ -211,9 +211,17 @@ public class AccountService {
 
     @Transactional(readOnly = true)
     public TransactionStatResponse getTransactionStats(Long userId, YearMonth startYm, YearMonth endYm) {
+
+        if (startYm == null || endYm == null) {
+            throw new CustomException(ErrorCode.INVALID_DATE_REQUEST);
+        }
+
+        if (startYm.isAfter(endYm)) {
+            throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
+        }
+
         Account account = accountRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
-
 
         // 1. 거래 내역 필터링
         List<Transaction> txs = account.getTransactions().stream()

--- a/src/main/java/com/example/mockbank/application/service/AccountService.java
+++ b/src/main/java/com/example/mockbank/application/service/AccountService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
@@ -225,7 +226,7 @@ public class AccountService {
                 }).toList();
 
         // 2. 월별로 분리
-        int monthCount = endYm.compareTo(startYm) + 1;
+        int monthCount = (int) ChronoUnit.MONTHS.between(startYm, endYm) + 1;
 
         // 3. 합계/평균 계산
         BigDecimal totalIncome = BigDecimal.ZERO;

--- a/src/main/java/com/example/mockbank/common/enums/ErrorCode.java
+++ b/src/main/java/com/example/mockbank/common/enums/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
     INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "잘못된 금액입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 예외입니다."),
-    INVALID_DATE_RANGE(HttpStatus.UNAUTHORIZED, "날짜 범위 설정이 잘못 되었습니다.");
+    INVALID_DATE_REQUEST(HttpStatus.UNAUTHORIZED, "시작 월, 종료 월 을 입력해주세요."),
+    INVALID_DATE_RANGE(HttpStatus.UNAUTHORIZED, "시작 월이 종료 월 이후이입니다.");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/mockbank/common/enums/ErrorCode.java
+++ b/src/main/java/com/example/mockbank/common/enums/ErrorCode.java
@@ -14,8 +14,7 @@ public enum ErrorCode {
     INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "잘못된 금액입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 예외입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
-
+    INVALID_DATE_RANGE(HttpStatus.UNAUTHORIZED, "날짜 범위 설정이 잘못 되었습니다.");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/mockbank/common/enums/SuccessCode.java
+++ b/src/main/java/com/example/mockbank/common/enums/SuccessCode.java
@@ -14,6 +14,7 @@ public enum SuccessCode {
     GET_USER_PROFILE_SUCCESS(HttpStatus.OK, "유저 프로필을 조회했습니다."),
     GET_ACCOUNT_SUCCESS(HttpStatus.OK, "계좌 잔액 조회를 성공했습니다."),
     GET_TRANSACTIONS_SUCCESS(HttpStatus.OK, "거래 내역 조회를 성공했습니다."),
+    GET_TRANSACTIONS_STATS_SUCCESS(HttpStatus.OK, "거래 내역 통계 조회를 성공했습니다."),
     DEPOSIT_SUCCESS(HttpStatus.OK, "입금이 완료되었습니다."),
     WITHDRAW_SUCCESS(HttpStatus.OK, "출금이 완료되었습니다.");
 

--- a/src/main/java/com/example/mockbank/common/redis/RedisService.java
+++ b/src/main/java/com/example/mockbank/common/redis/RedisService.java
@@ -5,11 +5,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Service;
 
-import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/mockbank/common/redis/RedisService.java
+++ b/src/main/java/com/example/mockbank/common/redis/RedisService.java
@@ -1,0 +1,27 @@
+package com.example.mockbank.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean exists(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public void set(String key, String value, Duration ttl) {
+        redisTemplate.opsForValue().set(key, value, ttl);
+    }
+}

--- a/src/main/java/com/example/mockbank/domain/account/entity/Account.java
+++ b/src/main/java/com/example/mockbank/domain/account/entity/Account.java
@@ -29,8 +29,12 @@ public class Account {
     @Column(nullable = false)
     private String userName;
 
+    @Setter
     @Column(nullable = false)
     private BigDecimal balance;
+
+    @Column(nullable = true)
+    private BigDecimal salary;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -41,6 +45,7 @@ public class Account {
     @Builder.Default
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Transaction> transactions = new ArrayList<>();
+
 
     public void deposit(BigDecimal amount) {
         this.balance = this.balance.add(amount);

--- a/src/main/java/com/example/mockbank/domain/account/entity/Account.java
+++ b/src/main/java/com/example/mockbank/domain/account/entity/Account.java
@@ -56,6 +56,4 @@ public class Account {
         this.balance = this.balance.subtract(amount);
         this.updatedAt = LocalDateTime.now();
     }
-
-
 }

--- a/src/main/java/com/example/mockbank/domain/account/entity/Account.java
+++ b/src/main/java/com/example/mockbank/domain/account/entity/Account.java
@@ -29,7 +29,6 @@ public class Account {
     @Column(nullable = false)
     private String userName;
 
-    @Setter
     @Column(nullable = false)
     private BigDecimal balance;
 
@@ -54,6 +53,11 @@ public class Account {
 
     public void withdraw(BigDecimal amount) {
         this.balance = this.balance.subtract(amount);
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateBalance(BigDecimal newBalance) {
+        this.balance = newBalance;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/mockbank/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/mockbank/domain/account/repository/AccountRepository.java
@@ -1,5 +1,7 @@
 package com.example.mockbank.domain.account.repository;
 
+import com.example.mockbank.common.enums.ErrorCode;
+import com.example.mockbank.common.exception.CustomException;
 import com.example.mockbank.domain.account.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +10,8 @@ import java.util.Optional;
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByUserId(Long userId);
     boolean existsByAccountNumber(String accountNumber);
+    default Account getOrThrowByUserId(Long userId) {
+        return findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
+    }
 }

--- a/src/main/resources/application-aws.properties
+++ b/src/main/resources/application-aws.properties
@@ -1,7 +1,8 @@
 # ARN & URL Only
 
 # account
-aws.sns.account-topic-arn=arn:aws:sns:ap-northeast-2:885378802418:account-created-topic-prod
+aws.url.sqs.account=https://sqs.ap-northeast-2.amazonaws.com/885378802418/account-created-queue-prod
+aws.arn.sns.account=arn:aws:sns:ap-northeast-2:885378802418:account-created-topic-prod
 
 # notification
 aws.url.sqs.notification=https://sqs.ap-northeast-2.amazonaws.com/885378802418/notification-created-queue-prod

--- a/src/main/resources/secrets/application-secret.example.properties
+++ b/src/main/resources/secrets/application-secret.example.properties
@@ -23,7 +23,7 @@ aws.region=ap-northeast-2
 aws.url.sqs.notification=https://sqs.ap-northeast-2.amazonaws.com/885378802418/notification-created-queue-dev
 aws.arn.sns.notification=arn:aws:sns:ap-northeast-2:885378802418:notification-created-topic-dev
 # account (dev)
-aws.url.sqs.account=https://sqs.ap-northeast-2.amazonaws.com/885378802418/account-created-queue-dev
+aws.url.sqs.account=https://sqs.ap-northeast-2.amazonaws.com/885378802418/account-created-queue-dev-(ksp/lhw/jkb/obt/sch)
 aws.arn.sns.account=arn:aws:sns:ap-northeast-2:885378802418:account-created-topic-dev
 
 # IAM Role (dev)

--- a/src/main/resources/secrets/application-secret.example.properties
+++ b/src/main/resources/secrets/application-secret.example.properties
@@ -23,8 +23,8 @@ aws.region=ap-northeast-2
 aws.url.sqs.notification=https://sqs.ap-northeast-2.amazonaws.com/885378802418/notification-created-queue-dev
 aws.arn.sns.notification=arn:aws:sns:ap-northeast-2:885378802418:notification-created-topic-dev
 # account (dev)
-aws.url.sqs.account=https://sqs.ap-northeast-2.amazonaws.com/885378802418/account-created-queue-dev-(ksp/lhw/jkb/obt/sch)
-aws.arn.sns.account=arn:aws:sns:ap-northeast-2:885378802418:account-created-topic-dev
+aws.url.sqs.account=https://sqs.ap-northeast-2.amazonaws.com/885378802418/account-created-queue-dev-(ksp/lhw/jkb/obt/sch/lhj)
+aws.arn.sns.account=arn:aws:sns:ap-northeast-2:885378802418:account-created-topic-dev-(ksp/lhw/jkb/obt/sch/lhj)
 
 # IAM Role (dev)
 aws.arn.role.message=arn:aws:iam::ACCOUNT_ID:role/role-message-adapter-dev

--- a/src/main/resources/secrets/application-secret.example.properties
+++ b/src/main/resources/secrets/application-secret.example.properties
@@ -19,12 +19,12 @@ aws.key.access.id=YOUR_AWS_ACCESS_KEY_ID
 aws.key.access.secret=YOUR_AWS_SECRET_ACCESS_KEY
 aws.region=ap-northeast-2
 
-# SQS (dev)
-aws.url.sqs.notification=https://sqs.ap-northeast-2.amazonaws.com/ACCOUNT_ID/notification-created-queue-dev
-
-# SNS (dev)
-aws.arn.sns.notification=arn:aws:sns:ap-northeast-2:ACCOUNT_ID:notification-created-topic-dev
-aws.sns.account-topic-arn=arn:aws:sns:ap-northeast-2:ACCOUNT_ID:account-created-topic-dev
+# notification (dev)
+aws.url.sqs.notification=https://sqs.ap-northeast-2.amazonaws.com/885378802418/notification-created-queue-dev
+aws.arn.sns.notification=arn:aws:sns:ap-northeast-2:885378802418:notification-created-topic-dev
+# account (dev)
+aws.url.sqs.account=https://sqs.ap-northeast-2.amazonaws.com/885378802418/account-created-queue-dev
+aws.arn.sns.account=arn:aws:sns:ap-northeast-2:885378802418:account-created-topic-dev
 
 # IAM Role (dev)
 aws.arn.role.message=arn:aws:iam::ACCOUNT_ID:role/role-message-adapter-dev

--- a/src/test/java/com/example/mockbank/adapter/in/messaging/AccountSqsListenerTest.java
+++ b/src/test/java/com/example/mockbank/adapter/in/messaging/AccountSqsListenerTest.java
@@ -22,8 +22,6 @@ class AccountSqsListenerTest {
 
     @Mock private AccountService accountService;
     @Mock private ObjectMapper objectMapper;
-    @Mock private software.amazon.awssdk.services.sqs.SqsClient sqsClient;
-
     @InjectMocks private AccountSqsListener listener;
 
     @Test


### PR DESCRIPTION
1. sns/sqs 중복/유실 방지 코드 추가
SQS 메시지의 messageId를 기반으로 account-event:{messageId} 형식의 키를 Redis에 1시간 TTL로 저장
이미 처리된 메시지의 경우, 즉시 skip 하도록 개선

정상 처리된 메시지에만 SQS 삭제(DeleteMessage) 수행

에러/커넥션풀 종료 시 적절한 로그 및 폴링 종료

2. 계좌 생성시 거래내역 자동생성 로직 구현

계좌 생성시 12~36개월치 랜덤 거래내역 생성, 달에 10~20개 거래내역 랜덤으로 생성, 총 자산은 음수 x 등

<img width="880" alt="스크린샷 2025-07-02 09 50 46" src="https://github.com/user-attachments/assets/5d34a0bc-9440-4cad-8252-415fe79e1eaa" />
<img width="747" alt="스크린샷 2025-07-02 09 55 32" src="https://github.com/user-attachments/assets/96c571d0-5f49-4aa6-9a18-251fc91ddc87" />


3. 거래내역 통계 조회 기능 추가

<img width="604" alt="스크린샷 2025-07-02 09 56 24" src="https://github.com/user-attachments/assets/abbcd73d-34c2-4af4-998d-6d73cb9809a7" />

지정한 기간 사이 총 수익, 총 지출, 평균 수익, 평균 지출 제공

4. 수정 및 추가 내용에 대한 테스트 코드 수정